### PR TITLE
ath79: add support for Comfast CF-E313AC v2

### DIFF
--- a/target/linux/ath79/dts/qca9563_comfast_cf-e313ac-v2.dts
+++ b/target/linux/ath79/dts/qca9563_comfast_cf-e313ac-v2.dts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "comfast,cf-e313ac-v2", "comfast,cf-a5", "qca,qca9563";
+	model = "COMFAST CF-E313AC v2";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_rssihigh;
+		led-failsafe = &led_rssihigh;
+		led-upgrade = &led_rssihigh;
+		label-mac-device = &eth0;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x08000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+
+		wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		rssilow {
+			label = "red:rssilow";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumlow {
+			label = "red:rssimediumlow";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumhigh {
+			label = "green:rssimediumhigh";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_rssihigh: rssihigh {
+			label = "green:rssihigh";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+
+		gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1000>;
+		always-running;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor", "mxicy,mx25l12805d";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "art";
+				reg = <0x040000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						/* LAN / label MAC Address */
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					serialnumber: serial@100 {
+						compatible = "linux,serial";
+						reg = <0x100 0x100>;
+					};
+
+					macaddr_art_1002: macaddr@1002 {
+						/* WAN MAC address */
+						reg = <0x1002 0x6>;
+					};
+
+					precal_art_5000: pre-calibration@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+				};
+			};
+
+			partition@7e0000 {
+				label = "configs";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "nvram";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xf90000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	reg = <0xb9000000 0x200>;
+
+	phy-handle = <&phy0>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+	};
+};
+
+&eth1 {
+	status = "disabled";
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+		nvmem-cells = <&precal_art_5000>, <&macaddr_art_6>;
+		nvmem-cell-names = "pre-calibration", "mac-address";
+	};
+};
+
+&wdt {
+	status = "disabled";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -176,6 +176,16 @@ comfast,cf-e313ac)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "76" "100"
 	;;
+comfast,cf-e313ac-v2)
+	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x04"
+	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x02"
+	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:rssilow" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "red:rssimediumlow" "wlan0" "26" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan0" "51" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "76" "100"
+	;;
 comfast,cf-e314n-v2)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -663,6 +663,10 @@ ath79_setup_macs()
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macb -i $(find_mtd_part "tffs (1)"))
 		;;
+	comfast,cf-e313ac-v2)
+		lan_mac=$(mtd_get_mac_binary art 0x0)
+		wan_mac=$(macaddr_add $(mtd_get_mac_binary art 0x0) 1)
+		;;
 	comfast,cf-e375ac)
 		wan_mac=$(macaddr_add $(mtd_get_mac_binary art 0x0) 1)
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -811,6 +811,17 @@ define Device/comfast_cf-e313ac
 endef
 TARGET_DEVICES += comfast_cf-e313ac
 
+define Device/comfast_cf-e313ac-v2
+  SOC := qca9563
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-E313AC
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := rssileds kmod-ath10k-ct kmod-netsemi \
+	ath10k-firmware-qca9888-ct -swconfig -uboot-envtools
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += comfast_cf-e313ac-v2
+
 define Device/comfast_cf-e314n-v2
   SOC := qca9531
   DEVICE_VENDOR := COMFAST


### PR DESCRIPTION
Specification:
  - Atheros QCA9563-AL3A 800MHz
  - 128MB RAM (Nanya NT5TU64M16HG-AC)
  - 16MB SPI NOR (MXIC MX25L12833F M2I-10G)
  - QCA9886 2x2 5GHz 802.11ac
  - QCA8337-AL3C 1GbE Ethernet switch
  - RS706C watchdog
  - 4 RSSI LEDs
  - 1 WAN LED
  - 1 LAN LED
  - 1 WLAN LED
  - 1 always-on power LED
  - 1 reset button
  - Serial UART solder pads and unpopulated pins
  - PoE supported on both Ethernet ports
  - on/off switch (presumably for PoE passthrough)

Two options tested for installation:
1. Use the stock firmware's update page
2. Use the uboot firmware flashing webui: a. Hold the reset button during boot b. When the lights start flashing, continue holding for 8 seconds c. Give your computer an IP address like 192.168.1.10 d. Open your browser to http://192.168.1.1 e. Use the form to select and upload your sysupgrade firmware file

TFTP flashing at boot is supported from 192.168.1.10.

The uboot console seemed to have keymap issues, so was not really tested.

Serial interface settings:
 uboot output: 128000,8n1
 linux: 115200,8n1
 uboot console: 57600,7n1?

